### PR TITLE
Add Firecrawl API URL configuration to environment template

### DIFF
--- a/owl/.env_template
+++ b/owl/.env_template
@@ -26,3 +26,4 @@ CHUNKR_API_KEY=""
 
 # Firecrawl API (https://www.firecrawl.dev/)
 FIRECRAWL_API_KEY=""
+#FIRECRAWL_API_URL="https://api.firecrawl.dev"


### PR DESCRIPTION
Added commented FIRECRAWL_API_URL variable to the .env_template file to support changing  Firecrawl API service URL. Users can uncomment and configure this variable when needed for local Firecrawl API access.