### PR TITLE
MINOR ISSUE:Fixed Webapp Command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,10 +405,10 @@ OWL includes an intuitive web-based user interface that makes it easier to inter
 
 ```bash
 # Start the Chinese version
-python run_app.py
+python app.py
 
 # Start the English version
-python run_app_en.py
+python app_en.py
 ```
 
 ## Features


### PR DESCRIPTION
In the README web interface section it instructs users to use the wrong file name so starting the webapp doesnt work. Currently there is `app.py` and `app_en.py` instead of `run_app.py` and `run_app_en.py`(from the README.md). 