### PR TITLE
[Fix] Path resolution in app(_en).py to support execution from any directory

### DIFF
--- a/owl/app.py
+++ b/owl/app.py
@@ -426,10 +426,13 @@ def run_script(script_dropdown, question, progress=gr.Progress()):
     log_file = log_dir / f"{script_name.replace('.py', '')}_{timestamp}.log"
 
     # 构建命令
+    # 获取当前脚本所在的基础路径
+    base_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
     cmd = [
         sys.executable,
-        os.path.join("owl", "script_adapter.py"),
-        os.path.join("owl", script_name),
+        os.path.join(base_path, "owl", "script_adapter.py"),
+        os.path.join(base_path, "owl", script_name),
     ]
 
     # 创建环境变量副本并添加问题
@@ -610,7 +613,7 @@ def create_ui():
         gr.Markdown(
             """
             # 🦉 OWL 智能助手运行平台
-            
+
             选择一个模型并输入您的问题，系统将运行相应的脚本并显示结果。
             """
         )
@@ -860,7 +863,7 @@ def create_ui():
         gr.Markdown(
             """
             ### 📝 使用说明
-            
+
             - 选择一个模型并输入您的问题
             - 点击"运行"按钮开始执行
             - 如需终止运行，点击"终止"按钮
@@ -869,9 +872,9 @@ def create_ui():
             - 在"聊天历史"标签页查看对话历史（如果有）
             - 在"环境变量配置"标签页配置API密钥和其他环境变量
             - 您可以添加自定义环境变量，满足特殊需求
-            
+
             ### ⚠️ 注意事项
-            
+
             - 运行某些模型可能需要API密钥，请确保在"环境变量配置"标签页中设置了相应的环境变量
             - 某些脚本可能需要较长时间运行，请耐心等待
             - 如果运行超过30分钟，进程将自动终止

--- a/owl/app_en.py
+++ b/owl/app_en.py
@@ -440,10 +440,11 @@ def run_script(script_dropdown, question, progress=gr.Progress()):
     log_file = log_dir / f"{script_name.replace('.py', '')}_{timestamp}.log"
 
     # Build command
+    base_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     cmd = [
         sys.executable,
-        os.path.join("owl", "script_adapter.py"),
-        os.path.join("owl", script_name),
+        os.path.join(base_path, "owl", "script_adapter.py"),
+        os.path.join(base_path, "owl", script_name),
     ]
 
     # Create a copy of environment variables and add the question
@@ -626,7 +627,7 @@ def create_ui():
         gr.Markdown(
             """
             # 🦉 OWL Intelligent Assistant Platform
-            
+
             Select a model and enter your question, the system will run the corresponding script and display the results.
             """
         )
@@ -889,7 +890,7 @@ def create_ui():
         gr.Markdown(
             """
             ### 📝 Instructions
-            
+
             - Select a model and enter your question
             - Click the "Run" button to start execution
             - To stop execution, click the "Stop" button
@@ -898,9 +899,9 @@ def create_ui():
             - View conversation history in the "Chat History" tab (if available)
             - Configure API keys and other environment variables in the "Environment Variable Configuration" tab
             - You can add custom environment variables to meet special requirements
-            
+
             ### ⚠️ Notes
-            
+
             - Running some models may require API keys, please make sure you have set the corresponding environment variables in the "Environment Variable Configuration" tab
             - Some scripts may take a long time to run, please be patient
             - If execution exceeds 30 minutes, the process will automatically terminate


### PR DESCRIPTION
## Problem
The current implementation of `app.run_script()` in `owl/owl/app.py` uses relative paths to locate script files. This causes errors when the application is launched from a directory other than the project root(e.g. in `owl/owl/` run `python app.py`), resulting in `'~/owl/owl/owl/script_adapter.py': [Errno 2] No such file or directory` errors because the path construction doesn't account for the actual location of the files.

## Solution
This PR modifies the path resolution to use absolute paths based on the location of the module itself (`__file__`), rather than relative paths from the current working directory. This ensures that script files can be found correctly regardless of where the application is executed from.

### Testing:
- Verified the application can now be executed from directories outside the project root
- Confirmed script execution works correctly with the new path resolution


