### PR TITLE
Add run script to use Groq provider

### DIFF
--- a/owl/.env_template
+++ b/owl/.env_template
@@ -4,6 +4,9 @@
 # OPENAI_API_KEY= ""
 # OPENAI_API_BASE_URL=""
 
+# When using GROQ remember to set OPENAI_API_BASE_URL to https://api.groq.com/openai/v1 to use the groq model according to https://console.groq.com/docs/openai
+# GROQ_API_KEY=""
+
 # Azure OpenAI API
 # AZURE_OPENAI_BASE_URL=""
 # AZURE_API_VERSION=""

--- a/owl/.env_template
+++ b/owl/.env_template
@@ -5,6 +5,7 @@
 # OPENAI_API_BASE_URL=""
 
 # When using GROQ remember to set OPENAI_API_BASE_URL to https://api.groq.com/openai/v1 to use the groq model according to https://console.groq.com/docs/openai
+# and set OPENAI_API_KEY equal to GROQ_API_KEY
 # GROQ_API_KEY=""
 
 # Azure OpenAI API

--- a/owl/run_groq.py
+++ b/owl/run_groq.py
@@ -1,0 +1,140 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+from dotenv import load_dotenv
+from camel.models import ModelFactory
+from camel.toolkits import (
+    AudioAnalysisToolkit,
+    CodeExecutionToolkit,
+    ExcelToolkit,
+    ImageAnalysisToolkit,
+    SearchToolkit,
+    VideoAnalysisToolkit,
+    BrowserToolkit,
+    FileWriteToolkit,
+)
+from camel.types import ModelPlatformType, ModelType
+from camel.logger import set_log_level
+
+from utils import OwlRolePlaying, run_society, DocumentProcessingToolkit
+
+load_dotenv()
+
+set_log_level(level="DEBUG")
+
+
+def construct_society(question: str) -> OwlRolePlaying:
+    r"""Construct a society of agents based on the given question.
+
+    Args:
+        question (str): The task or question to be addressed by the society.
+
+    Returns:
+        OwlRolePlaying: A configured society of agents ready to address the question.
+    """
+
+    # Create models for different components
+    models = {
+        "user": ModelFactory.create(
+            model_platform=ModelPlatformType.GROQ,
+            model_type=ModelType.GROQ_LLAMA_3_1_8B,
+            model_config_dict={"temperature": 0},
+        ),
+        "assistant": ModelFactory.create(
+            model_platform=ModelPlatformType.GROQ,
+            model_type=ModelType.GROQ_LLAMA_3_1_8B,
+            model_config_dict={"temperature": 0},
+        ),
+        "web": ModelFactory.create(
+            model_platform=ModelPlatformType.GROQ,
+            model_type=ModelType.GROQ_LLAMA_3_1_8B,
+            model_config_dict={"temperature": 0},
+        ),
+        "planning": ModelFactory.create(
+            model_platform=ModelPlatformType.GROQ,
+            model_type=ModelType.GROQ_LLAMA_3_1_8B,
+            model_config_dict={"temperature": 0},
+        ),
+        "video": ModelFactory.create(
+            model_platform=ModelPlatformType.GROQ,
+            model_type=ModelType.GROQ_LLAMA_3_1_8B,
+            model_config_dict={"temperature": 0},
+        ),
+        "image": ModelFactory.create(
+            model_platform=ModelPlatformType.GROQ,
+            model_type=ModelType.GROQ_LLAMA_3_1_8B,
+            model_config_dict={"temperature": 0},
+        ),
+        "document": ModelFactory.create(
+            model_platform=ModelPlatformType.GROQ,
+            model_type=ModelType.GROQ_LLAMA_3_1_8B,
+            model_config_dict={"temperature": 0},
+        ),
+    }
+
+    # Configure toolkits
+    tools = [
+        *BrowserToolkit(
+            headless=False,  # Set to True for headless mode (e.g., on remote servers)
+            web_agent_model=models["web"],
+            planning_agent_model=models["planning"],
+        ).get_tools(),
+        *VideoAnalysisToolkit(model=models["video"]).get_tools(),
+        *AudioAnalysisToolkit().get_tools(),  # This requires OpenAI Key
+        *CodeExecutionToolkit(sandbox="subprocess", verbose=True).get_tools(),
+        *ImageAnalysisToolkit(model=models["image"]).get_tools(),
+        SearchToolkit().search_duckduckgo,
+        SearchToolkit().search_google,  # Comment this out if you don't have google search
+        SearchToolkit().search_wiki,
+        *ExcelToolkit().get_tools(),
+        *DocumentProcessingToolkit(model=models["document"]).get_tools(),
+        *FileWriteToolkit(output_dir="./").get_tools(),
+    ]
+
+    # Configure agent roles and parameters
+    user_agent_kwargs = {"model": models["user"]}
+    assistant_agent_kwargs = {"model": models["assistant"], "tools": tools}
+
+    # Configure task parameters
+    task_kwargs = {
+        "task_prompt": question,
+        "with_task_specify": False,
+    }
+
+    # Create and return the society
+    society = OwlRolePlaying(
+        **task_kwargs,
+        user_role_name="user",
+        user_agent_kwargs=user_agent_kwargs,
+        assistant_role_name="assistant",
+        assistant_agent_kwargs=assistant_agent_kwargs,
+    )
+
+    return society
+
+
+def main():
+    r"""Main function to run the OWL system with an example question."""
+    # Example research question
+    question = "Navigate to Amazon.com and identify one product that is attractive to coders. Please provide me with the product name and price. No need to verify your answer."
+
+    # Construct and run the society
+    society = construct_society(question)
+    answer, chat_history, token_count = run_society(society)
+
+    # Output the result
+    print(f"\033[94mAnswer: {answer}\033[0m")
+
+
+if __name__ == "__main__":
+    main()

--- a/owl/run_groq.py
+++ b/owl/run_groq.py
@@ -11,6 +11,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+
+"""
+This module provides integration with the Groq API platform for the OWL system.
+
+It configures different agent roles with appropriate Groq models based on their requirements:
+- Tool-intensive roles (assistant, web, planning, video, image) use GROQ_LLAMA_3_3_70B
+- Document processing uses GROQ_MIXTRAL_8_7B
+- Simple roles (user) use GROQ_LLAMA_3_1_8B
+
+To use this module:
+1. Set GROQ_API_KEY in your .env file
+2. Set OPENAI_API_BASE_URL to "https://api.groq.com/openai/v1"
+3. Run with: python -m owl.run_groq
+"""
+
 from dotenv import load_dotenv
 from camel.models import ModelFactory
 from camel.toolkits import (
@@ -47,37 +62,37 @@ def construct_society(question: str) -> OwlRolePlaying:
     models = {
         "user": ModelFactory.create(
             model_platform=ModelPlatformType.GROQ,
-            model_type=ModelType.GROQ_LLAMA_3_1_8B,
+            model_type=ModelType.GROQ_LLAMA_3_1_8B,  # Simple role, can use 8B model
             model_config_dict={"temperature": 0},
         ),
         "assistant": ModelFactory.create(
             model_platform=ModelPlatformType.GROQ,
-            model_type=ModelType.GROQ_LLAMA_3_1_8B,
+            model_type=ModelType.GROQ_LLAMA_3_3_70B,  # Main assistant needs tool capability
             model_config_dict={"temperature": 0},
         ),
         "web": ModelFactory.create(
             model_platform=ModelPlatformType.GROQ,
-            model_type=ModelType.GROQ_LLAMA_3_1_8B,
+            model_type=ModelType.GROQ_LLAMA_3_3_70B,  # Web browsing requires tool usage
             model_config_dict={"temperature": 0},
         ),
         "planning": ModelFactory.create(
             model_platform=ModelPlatformType.GROQ,
-            model_type=ModelType.GROQ_LLAMA_3_1_8B,
+            model_type=ModelType.GROQ_LLAMA_3_3_70B,  # Planning requires complex reasoning
             model_config_dict={"temperature": 0},
         ),
         "video": ModelFactory.create(
             model_platform=ModelPlatformType.GROQ,
-            model_type=ModelType.GROQ_LLAMA_3_1_8B,
+            model_type=ModelType.GROQ_LLAMA_3_3_70B,  # Video analysis is multimodal
             model_config_dict={"temperature": 0},
         ),
         "image": ModelFactory.create(
             model_platform=ModelPlatformType.GROQ,
-            model_type=ModelType.GROQ_LLAMA_3_1_8B,
+            model_type=ModelType.GROQ_LLAMA_3_3_70B,  # Image analysis is multimodal
             model_config_dict={"temperature": 0},
         ),
         "document": ModelFactory.create(
             model_platform=ModelPlatformType.GROQ,
-            model_type=ModelType.GROQ_LLAMA_3_1_8B,
+            model_type=ModelType.GROQ_MIXTRAL_8_7B,  # Document processing can use Mixtral
             model_config_dict={"temperature": 0},
         ),
     }
@@ -129,6 +144,9 @@ def main():
     question = "Navigate to Amazon.com and identify one product that is attractive to coders. Please provide me with the product name and price. No need to verify your answer."
 
     # Construct and run the society
+    # Note: This configuration uses GROQ_LLAMA_3_3_70B for tool-intensive roles (assistant, web, planning, video, image)
+    # and GROQ_MIXTRAL_8_7B for document processing. GROQ_LLAMA_3_1_8B is used only for the user role
+    # which doesn't require tool usage capabilities.
     society = construct_society(question)
     answer, chat_history, token_count = run_society(society)
 


### PR DESCRIPTION
## Overview
This pull request adds support for the Groq API platform to the OWL system. It enables users to leverage Groq's LLaMA 3.1 8B model for various agent roles within the OWL society framework, providing an alternative to existing model providers.

## Changes
- Created a dedicated `run_groq.py` script to demonstrate Groq model usage
- Updated environment template with Groq API configuration instructions
- Configured all agent roles (user, assistant, web, planning, video, image, document) to use Groq's LLaMA 3.1 8B model
- Set default temperature to 0 for deterministic outputs

## Implementation Details
- The implementation follows the existing pattern for model platform integration
- Groq API is accessed through the OpenAI-compatible endpoint (https://api.groq.com/openai/v1)
- All agent roles are configured with the same model type for consistency
- The system maintains compatibility with existing toolkits and workflows

## Testing
- Verified successful connection to Groq API
- Tested the system with example research questions

## Documentation
- Added comments explaining Groq API configuration
- Updated .env_template with instructions for setting up Groq API credentials
- Included example usage in run_groq.py

## Benefits
- Provides users with access to Groq's high-performance inference platform
- Offers an alternative to existing model providers
- Maintains the same functionality while potentially improving response speed
- Enables experimentation with Groq's implementation of LLaMA 3.1

## How to Use
1. Set `GROQ_API_KEY` in your .env file
2. Set `OPENAI_API_BASE_URL` to "https://api.groq.com/openai/v1"
3. Run the system using `python owl/run_groq.py`

