### PR TITLE
Add missing directory to Docker container mount

### DIFF
--- a/.container/docker-compose.yml
+++ b/.container/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     volumes:
       # 挂载.env文件，方便配置API密钥
       - ../owl/.env:/app/owl/.env
+      # 挂载example文件夹，以支持docker容器内运行代码案例
+      - ../examples:/app/examples
       # 挂载数据目录
       - ./data:/app/owl/data
       # 挂载缓存目录，避免重复下载


### PR DESCRIPTION
A previously omitted directory `~/examples` was missing from the Docker container mount configuration. This has now been added to ensure proper functionality.

This fixes the issue mentioned at #318.