### PR TITLE
Fixing incorrect import path in run_groq.py

### DIFF
--- a/examples/run_groq.py
+++ b/examples/run_groq.py
@@ -41,7 +41,7 @@ from camel.toolkits import (
 from camel.types import ModelPlatformType, ModelType
 from camel.logger import set_log_level
 
-from utils import OwlRolePlaying, run_society, DocumentProcessingToolkit
+from owl.utils import OwlRolePlaying, run_society, DocumentProcessingToolkit
 
 load_dotenv()
 


### PR DESCRIPTION
Hi,
Fixing import patch for utils in on examples/run_groq.py.

Current `utils` is incorrect, it must be `owl.utils`otherwise Python errors on items `OwlRolePlaying, run_society, DocumentProcessingToolkit`

See commit diff for details

Didier