### PR TITLE
fix run.py demo

### DIFF
--- a/examples/run.py
+++ b/examples/run.py
@@ -135,7 +135,9 @@ def main():
 
     # Construct and run the society
     society = construct_society(question)
-    answer, chat_history, token_count = run_society(society)
+    
+    import asyncio
+    answer, chat_history, token_count = asyncio.run(run_society(society))
 
     # Output the result
     print(f"\033[94mAnswer: {answer}\033[0m")


### PR DESCRIPTION
Hi, I got an error when running run.py.
```
(owlTest) root@DESKTOP-QNBEB8P:/home/jjyaoao/openSource/owl# python owl/run.py 
2025-03-18 21:33:50,589 - camel - DEBUG - Logging level set to: 10
2025-03-18 21:33:57,155 - camel.camel.toolkits.video_download_toolkit - INFO - Video will be downloaded to /tmp/tmpnk91551v
2025-03-18 21:33:57,155 - camel.camel.toolkits.video_analysis_toolkit - INFO - Video will be downloaded to /tmp/tmpnk91551v
2025-03-18 21:33:57,235 - camel.camel.toolkits.audio_analysis_toolkit - WARNING - No audio transcription model provided. Using OpenAIAudioModels.
2025-03-18 21:33:57,308 - camel.camel.toolkits.audio_analysis_toolkit - WARNING - No audio reasoning model provided. Using default model in ChatAgent.
2025-03-18 21:33:57,325 - camel.camel.toolkits.file_write_toolkit - INFO - FileWriteToolkit initialized with output directory: /home/jjyaoao/openSource/owl, encoding: utf-8
/home/jjyaoao/openSource/owl/owl/run.py:133: RuntimeWarning: coroutine 'run_society' was never awaited
  answer, chat_history, token_count = run_society(society)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
Traceback (most recent call last):
  File "/home/jjyaoao/openSource/owl/owl/run.py", line 140, in <module>
    main()
  File "/home/jjyaoao/openSource/owl/owl/run.py", line 133, in main
    answer, chat_history, token_count = run_society(society)
TypeError: cannot unpack non-iterable coroutine object
2025-03-18 21:33:57,490 - camel.camel.toolkits.video_analysis_toolkit - DEBUG - Removed temporary directory: /tmp/tmpnk91551v
```

Importing the asyncio module can solve this problem. You can test whether you need to accept this PR
