### PR TITLE
adding launch parameter to allow remote access to containerized OWL

### DIFF
--- a/owl/webapp.py
+++ b/owl/webapp.py
@@ -1294,7 +1294,13 @@ def main():
         app = create_ui()
 
         app.queue()
-        app.launch(share=False, favicon_path="../assets/owl-favicon.ico")
+        launch_kwargs = {
+            "share": False,
+            "favicon_path": "../assets/owl-favicon.ico"
+        }
+        if os.getenv("OWL_SERVER_NAME") is not None:
+            launch_kwargs["server_name"] = os.getenv("OWL_SERVER_NAME")
+        app.launch(**launch_kwargs)
     except Exception as e:
         logging.error(f"Error occurred while starting the application: {str(e)}")
         print(f"Error occurred while starting the application: {str(e)}")


### PR DESCRIPTION
Hi, 

In multiple use cases, when running on the cloud, OWL needs to allow remote access to Gradio UI. The `server_name` parameter of app launch() defines which ip adresses have access to the OWL ui.

default value `127.0.0.1` (aka localhost) which is default doesn't allow for remote access (local host is not routable). So, we define a new ENV var OWL_SERVER_NAME (easy to define at container start) that allows to replace the default by new one.

In our use case, we use "0.0.0.0" (all ip adresses) as value for ip addresses when starting our OWL container. It works just fine.