### PR TITLE
Feat: Safe OWL Society Termination

### DIFF
--- a/owl/utils/enhanced_role_playing.py
+++ b/owl/utils/enhanced_role_playing.py
@@ -436,10 +436,11 @@ class OwlGAIARolePlaying(OwlRolePlaying):
             ),
         )
 
-
+import threading
 def run_society(
     society: OwlRolePlaying,
     round_limit: int = 15,
+    stop_event: threading.Event = None
 ) -> Tuple[str, List[dict], dict]:
     overall_completion_token_count = 0
     overall_prompt_token_count = 0
@@ -488,6 +489,7 @@ def run_society(
             assistant_response.terminated
             or user_response.terminated
             or "TASK_DONE" in user_response.msg.content
+            or (stop_event and stop_event.is_set())
         ):
             break
 

--- a/owl/webapp.py
+++ b/owl/webapp.py
@@ -1337,7 +1337,7 @@ def create_ui():
             outputs=[log_display2],
         )
 
-        # No longer automatically refresh logs by default
+        app.load(update_interface, outputs=[token_count_output, status_output, log_display2, run_button, stop_button], every=1)
 
     return app
 


### PR DESCRIPTION
This Stop OWL feature enables users to terminate from long running ***Multi Turn*** processes safely. It does it by using present mechanisms to break the for loop. Current limitation is that it breaks the loop after a full turn, thus taking time if CoT in single Agent is involved, drilling Event to ChatbotAgent and society creation is required to achieve almost immediate termination. This PR closes #362 by @didier-durand 

https://github.com/user-attachments/assets/af675f29-ec7f-4a65-87e0-c03e1d7a95fb


## Added:
1. stop_owl function. It triggers the STOP_REQUESTED Thread Event
2. I passed this event to run_society() and added a check in the for loop.
```python
answer, chat_history, token_info = run_society(
      society=society, 
      stop_event=STOP_REQUESTED
  )
```

## Changed:
1. I had to move live_logs function to separate thread. This code was causing the Event queue to wait until the process_with_live_logs() was over, queueing thus invalidating stop_owl() events
```python
def run_button_event():
.....
 while bg_thread.is_alive():
      # Update conversation record display
      logs2 = get_latest_logs(100, LOG_QUEUE)

      # Always update status
      yield (
          "0",
          "<span class='status-indicator status-running'></span> Processing...",
          logs2,
      )

      time.sleep(1)
````
2. After changing to async, asyncio threads doesn't support Generators (yield) while we need to send real-time data back to components. So, caused State management to change to Global or Session state.

## Limitation of Current Approach:
1. The STOP_REQUESTED Event is getting triggered on time, but the condition check is getting delayed until a full loop is complete i.e. If Chain Of Thought (CoT) is getting processed by anyone of agents, then it won't terminate. Perhaps anyone can help Drilling the STOP_REQUESTED event deep inside Chat Agent or society creation.
2. A different issue is causing the feature not to be that useful. I have mentioned it in this issue 👉 #449 

## Notes on State Mgmt:
- This code uses Global State, thus making Web Page refreshes stateful. But will make it share state to other users if sharing is enabled:
>app.launch(share=True)

- This can be solved easily solved by refactoring to Gradio's Session state (gr.State({})). But due to the nature of decoupled processing, run_owl() also needs to be stateless. This side effect will cause gradio to create a new state after refreshing the page while the deamon is running OWL

Just a note, I found Gradio Auto refresh was turned off intentionally, I think it was to simplify the code by using Generators instead of managing State but I am interested to know the reason (Not to break anything :D).
Currently all changes are stored to a global STATE then app updates components every second
```python
app.load(update_interface, outputs=[token_count_output, status_output, log_display2, run_button, stop_button], every=1)
```