### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix a typo

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,11 @@ repos:
       language: system
       types: [python]
       exclude: ^docs/cookbooks/  # Ignore files under docs/cookbooks
+
+  - repo: https://github.com/codespell-project/codespell
+    # Configuration for codespell is in pyproject.toml
+    rev: v2.4.1
+    hooks:
+    - id: codespell
+      additional_dependencies:
+      - tomli  # for python_version < '3.11'

--- a/community_usecase/virtual_fitting_room/readme.md
+++ b/community_usecase/virtual_fitting_room/readme.md
@@ -7,7 +7,7 @@ All with one prompt 🪄
 
 ## Dependencies:
 
- 1. I made some modificaitons to the camel repo so please first run "git clone -b feature/virtual-try-on-toolkit-and-partial-screenshot --single-branch https://github.com/camel-ai/camel.git"
+ 1. I made some modifications to the camel repo so please first run "git clone -b feature/virtual-try-on-toolkit-and-partial-screenshot --single-branch https://github.com/camel-ai/camel.git"
  2. fill in your klingai api keys for virtual try-on in camel/toolkits/virtual_try_on_toolkit.py (you can get it from https://klingai.kuaishou.com/dev-center)
  3. pip install the above cloned repo
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,5 +64,5 @@ ignore_missing_imports = true
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = '.git*,*.pdf,*.lock'
 check-hidden = true
-# ignore-regex = ''
-# ignore-words-list = ''
+ignore-regex = '\bBrin\b'
+ignore-words-list = 'datas'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,10 @@ follow_imports = "skip"
 [[tool.mypy.overrides]]
 module = "utils"
 ignore_missing_imports = true
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.pdf,*.lock'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

Although currently only 1 typo found/fixed, fixing typos has been very popular recently ;)

```shell
❯ git lg origin/main  | grep typo
* | | 3140c05 - fix typo (11 days ago) [Wendong]
*   86e03a1 - Fixing typo visible in webapp.py: fresh re-iteration of https://github.com/camel-ai/owl/pull/331 (#380) (12 days ago) [Wendong-Fan]
| * 171c945 - Fixing typo visible in webapp.py (13 days ago) [Didier Durand]
* | 1da3805 - fix readme typo (3 weeks ago) [Wendong]
* da096d1 - fix typo (4 weeks ago) [lazychih114]
* 2436c21 - fix typo (4 weeks ago) [lazychih114]
```

so with codespell it might become needed less