### PR TITLE
fix Github workflow for Docker build to avoid failing runs on forks

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,6 +11,12 @@ jobs:
   build-and-push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
+
+    # Only run on main repo on and PRs that match the main repo.
+    if: |
+      github.repository == 'camel-ai/owl' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
Currently the Docker build workflow in .github dir will fail due to missing credentials when running on forks of main repo.

This PR avoids the workflow to fail on forks

Thanks

Didier