### PR TITLE
Refactor UI theme settings in webapp_zh.py

### DIFF
--- a/owl/webapp_zh.py
+++ b/owl/webapp_zh.py
@@ -842,7 +842,7 @@ def create_ui():
                 logs2,
             )
 
-    with gr.Blocks(theme=gr.themes.Soft(primary_hue="blue")) as app:
+    with gr.Blocks() as app:
         gr.Markdown(
             """
                 # 🦉 OWL 多智能体协作系统
@@ -1067,7 +1067,6 @@ def create_ui():
                     placeholder="请输入您的问题...",
                     label="问题",
                     elem_id="question_input",
-                    show_copy_button=True,
                     value="打开百度搜索，总结一下camel-ai的camel框架的github star、fork数目等，并把数字用plot包写成python文件保存到本地，并运行生成的python文件。",
                 )
 
@@ -1273,7 +1272,7 @@ def main():
         app = create_ui()
 
         app.queue()
-        app.launch(share=False)
+        app.launch(share=False, theme=gr.themes.Soft(primary_hue="blue"))
     except Exception as e:
         logging.error(f"启动应用程序时发生错误: {str(e)}")
         print(f"启动应用程序时发生错误: {str(e)}")


### PR DESCRIPTION
- Removed explicit theme setting in Blocks initialization.
- Restored theme setting in app launch method.
- Removed unnecessary copy button from question input.

修复背景与环境
在 Python 3.10 环境下使用 Gradio 6.0 构建 OWL 多智能体协作系统的 Web 界面时，启动出现兼容性错误，导致应用无法正常启动。
问题分析与修复理由
问题 1：show_copy_button 参数不兼容
原因：在代码第 1070 行的 gr.Textbox() 中使用了 show_copy_button=True，但当前 Gradio 版本（可能低于支持的版本）的 Textbox 组件不接收该参数。
错误信息：TypeError: Textbox.__init__() got an unexpected keyword argument 'show_copy_button'
修复：移除该参数。show_copy_button 在较新版本才支持，当前环境不支持，移除不影响核心功能。
问题 2：theme 参数位置不符合 Gradio 6.0 规范
原因：Gradio 6.0 将 theme 参数从 gr.Blocks() 构造函数移至 app.launch()。
错误信息：UserWarning: The parameters have been moved from the Blocks constructor to the launch() method in Gradio 6.0: theme
修复：将 theme=gr.themes.Soft(primary_hue="blue") 从 gr.Blocks() 移至 app.launch()，符合 6.0 的 API 变更。
-------------------
Fix Background and Environment
When building the OWL multi-agent collaboration system web interface using Gradio 6.0 under Python 3.10, compatibility errors occurred during startup, preventing the application from launching normally.
Issue Analysis and Fix Rationale
Issue 1: show_copy_button Parameter Incompatibility
Root Cause: The code at line 1070 used show_copy_button=True in gr.Textbox(), but the current Gradio version (possibly older than the version that supports this parameter) does not accept this parameter in the Textbox component.
Error Message: TypeError: Textbox.__init__() got an unexpected keyword argument 'show_copy_button'
Fix Rationale: This parameter is supported in newer Gradio versions but not in the current environment. Removing it doesn't affect core functionality, and the text input works normally without this feature.
Issue 2: theme Parameter Location Non-compliance with Gradio 6.0 Specification
Root Cause: Gradio 6.0 moved the theme parameter from the gr.Blocks() constructor to the app.launch() method as part of an API change.
Error Message: UserWarning: The parameters have been moved from the Blocks constructor to the launch() method in Gradio 6.0: theme
Fix Rationale: Moving theme=gr.themes.Soft(primary_hue="blue") from gr.Blocks() to app.launch() aligns with Gradio 6.0's API changes, ensuring correct theme application and eliminating warnings.
Summary of Fixes
Removed the show_copy_button=True parameter (line 1070)
Moved the theme parameter from gr.Blocks() to app.launch() (lines 845 and 1275)
After these fixes, the application can start and run normally in the Python 3.10 + Gradio 6.0 environment.