### PR TITLE
feat: add MiniMax as LLM provider (default: MiniMax-M3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,9 @@ python examples/run_azure_openai.py
 
 # Run with Ollama
 python examples/run_ollama.py
+
+# Run with MiniMax model (MiniMax-M2.7)
+python examples/run_minimax.py
 ```
 
 For a simpler version that only requires an LLM API key, you can try our minimal example:

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ python examples/run_azure_openai.py
 # Run with Ollama
 python examples/run_ollama.py
 
-# Run with MiniMax model (MiniMax-M2.7)
+# Run with MiniMax model (MiniMax-M3)
 python examples/run_minimax.py
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -408,6 +408,9 @@ python examples/run_azure_openai.py
 
 # 使用 Ollama 运行
 python examples/run_ollama.py
+
+# 使用 MiniMax 模型 (MiniMax-M2.7) 运行
+python examples/run_minimax.py
 ```
 
 你可以通过修改 `examples/run.py` 脚本来运行自己的任务：

--- a/README_zh.md
+++ b/README_zh.md
@@ -409,7 +409,7 @@ python examples/run_azure_openai.py
 # 使用 Ollama 运行
 python examples/run_ollama.py
 
-# 使用 MiniMax 模型 (MiniMax-M2.7) 运行
+# 使用 MiniMax 模型 (MiniMax-M3) 运行
 python examples/run_minimax.py
 ```
 

--- a/examples/run_minimax.py
+++ b/examples/run_minimax.py
@@ -1,0 +1,241 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+
+"""
+Workforce example using MiniMax models via the OpenAI-compatible API.
+
+MiniMax provides powerful language models with tool calling support and
+up to 1M token context windows. This example demonstrates how to use
+MiniMax models (MiniMax-M2.7) with the OWL multi-agent workforce.
+
+To use this file:
+1. Get your API key from https://platform.minimaxi.com/
+2. Set MINIMAX_API_KEY="your-api-key" in your .env file
+3. Run with: python examples/run_minimax.py
+"""
+
+import os
+import sys
+import pathlib
+from dotenv import load_dotenv
+from camel.models import ModelFactory
+from camel.agents import ChatAgent
+from camel.toolkits import (
+    FunctionTool,
+    CodeExecutionToolkit,
+    ExcelToolkit,
+    SearchToolkit,
+    FileToolkit,
+)
+from camel.types import ModelPlatformType
+from camel.logger import set_log_level
+from camel.tasks.task import Task
+
+from camel.societies import Workforce
+
+from owl.utils import DocumentProcessingToolkit
+
+from typing import List, Dict, Any
+
+base_dir = pathlib.Path(__file__).parent.parent
+env_path = base_dir / "owl" / ".env"
+load_dotenv(dotenv_path=str(env_path))
+
+set_log_level(level="DEBUG")
+
+# MiniMax API configuration
+MINIMAX_API_URL = "https://api.minimax.io/v1"
+MINIMAX_MODEL = "MiniMax-M2.7"
+
+
+def construct_agent_list() -> List[Dict[str, Any]]:
+    """Construct a list of agents with their configurations."""
+
+    api_key = os.getenv("MINIMAX_API_KEY")
+
+    web_model = ModelFactory.create(
+        model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
+        model_type=MINIMAX_MODEL,
+        url=MINIMAX_API_URL,
+        api_key=api_key,
+        model_config_dict={"temperature": 0},
+    )
+
+    document_processing_model = ModelFactory.create(
+        model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
+        model_type=MINIMAX_MODEL,
+        url=MINIMAX_API_URL,
+        api_key=api_key,
+        model_config_dict={"temperature": 0},
+    )
+
+    reasoning_model = ModelFactory.create(
+        model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
+        model_type=MINIMAX_MODEL,
+        url=MINIMAX_API_URL,
+        api_key=api_key,
+        model_config_dict={"temperature": 0},
+    )
+
+    search_toolkit = SearchToolkit()
+    document_processing_toolkit = DocumentProcessingToolkit(
+        model=document_processing_model
+    )
+    code_runner_toolkit = CodeExecutionToolkit(sandbox="subprocess", verbose=True)
+    file_toolkit = FileToolkit()
+    excel_toolkit = ExcelToolkit()
+
+    web_agent = ChatAgent(
+        """You are a helpful assistant that can search the web, extract webpage content, and provide relevant information to solve the given task.
+Keep in mind that:
+- Do not be overly confident in your own knowledge. Searching can provide a broader perspective and help validate existing knowledge.
+- If one way fails to provide an answer, try other ways or methods. The answer does exist.
+- When looking for specific numerical values (e.g., dollar amounts), prioritize reliable sources.
+- When solving tasks that require web searches, check Wikipedia first before exploring other websites.
+- In your response, you should mention the urls you have visited and processed.
+
+Here are some tips that help you perform web search:
+- Never add too many keywords in your search query!
+- If the question is complex, search results typically do not provide precise answers. The search query should be concise and focuses on finding official sources rather than direct answers.
+- The results you return do not have to directly answer the original question, you only need to collect relevant information.
+""",
+        model=web_model,
+        tools=[
+            FunctionTool(search_toolkit.search_duckduckgo),
+            FunctionTool(search_toolkit.search_wiki),
+            FunctionTool(search_toolkit.search_baidu),
+            FunctionTool(document_processing_toolkit.extract_document_content),
+        ],
+    )
+
+    document_processing_agent = ChatAgent(
+        "You are a helpful assistant that can process documents and multimodal data, and can interact with file system.",
+        document_processing_model,
+        tools=[
+            FunctionTool(document_processing_toolkit.extract_document_content),
+            FunctionTool(code_runner_toolkit.execute_code),
+            *file_toolkit.get_tools(),
+        ],
+    )
+
+    reasoning_coding_agent = ChatAgent(
+        "You are a helpful assistant that specializes in reasoning and coding, and can think step by step to solve the task. When necessary, you can write python code to solve the task. If you have written code, do not forget to execute the code. Never generate codes like 'example code', your code should be able to fully solve the task. You can also leverage multiple libraries, such as requests, BeautifulSoup, re, pandas, etc, to solve the task. For processing excel files, you should write codes to process them.",
+        reasoning_model,
+        tools=[
+            FunctionTool(code_runner_toolkit.execute_code),
+            FunctionTool(excel_toolkit.extract_excel_content),
+            FunctionTool(document_processing_toolkit.extract_document_content),
+        ],
+    )
+
+    agent_list = []
+
+    web_agent_dict = {
+        "name": "Web Agent",
+        "description": "A helpful assistant that can search the web, extract webpage content, and retrieve relevant information.",
+        "agent": web_agent,
+    }
+
+    document_processing_agent_dict = {
+        "name": "Document Processing Agent",
+        "description": "A helpful assistant that can process a variety of local and remote documents, including pdf, docx, images, audio, and video, etc.",
+        "agent": document_processing_agent,
+    }
+
+    reasoning_coding_agent_dict = {
+        "name": "Reasoning Coding Agent",
+        "description": "A helpful assistant that specializes in reasoning, coding, and processing excel files. However, it cannot access the internet to search for information. If the task requires python execution, it should be informed to execute the code after writing it.",
+        "agent": reasoning_coding_agent,
+    }
+
+    agent_list.append(web_agent_dict)
+    agent_list.append(document_processing_agent_dict)
+    agent_list.append(reasoning_coding_agent_dict)
+    return agent_list
+
+
+def construct_workforce() -> Workforce:
+    """Construct a workforce with coordinator and task agents."""
+
+    api_key = os.getenv("MINIMAX_API_KEY")
+
+    coordinator_agent_kwargs = {
+        "model": ModelFactory.create(
+            model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
+            model_type=MINIMAX_MODEL,
+            url=MINIMAX_API_URL,
+            api_key=api_key,
+            model_config_dict={"temperature": 0},
+        )
+    }
+
+    task_agent_kwargs = {
+        "model": ModelFactory.create(
+            model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
+            model_type=MINIMAX_MODEL,
+            url=MINIMAX_API_URL,
+            api_key=api_key,
+            model_config_dict={"temperature": 0},
+        )
+    }
+
+    task_agent = ChatAgent(
+        "You are a helpful assistant that can decompose tasks and assign tasks to workers.",
+        **task_agent_kwargs,
+    )
+
+    coordinator_agent = ChatAgent(
+        "You are a helpful assistant that can assign tasks to workers.",
+        **coordinator_agent_kwargs,
+    )
+
+    workforce = Workforce(
+        "Workforce",
+        task_agent=task_agent,
+        coordinator_agent=coordinator_agent,
+    )
+
+    agent_list = construct_agent_list()
+
+    for agent_dict in agent_list:
+        workforce.add_single_agent_worker(
+            agent_dict["description"],
+            worker=agent_dict["agent"],
+        )
+
+    return workforce
+
+
+def main():
+    r"""Main function to run the OWL system with an example question."""
+    # Default research question
+    default_task_prompt = "Search for recent news about the OWL project and generate a report, then save it locally."
+
+    # Override default task if command line argument is provided
+    task_prompt = sys.argv[1] if len(sys.argv) > 1 else default_task_prompt
+
+    task = Task(
+        content=task_prompt,
+    )
+
+    workforce = construct_workforce()
+
+    processed_task = workforce.process_task(task)
+
+    # Output the result
+    print(f"\033[94mAnswer: {processed_task.result}\033[0m")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/run_minimax.py
+++ b/examples/run_minimax.py
@@ -16,8 +16,8 @@
 Workforce example using MiniMax models via the OpenAI-compatible API.
 
 MiniMax provides powerful language models with tool calling support and
-up to 1M token context windows. This example demonstrates how to use
-MiniMax models (MiniMax-M2.7) with the OWL multi-agent workforce.
+large context windows. This example demonstrates how to use
+MiniMax models (MiniMax-M3) with the OWL multi-agent workforce.
 
 To use this file:
 1. Get your API key from https://platform.minimaxi.com/
@@ -56,7 +56,7 @@ set_log_level(level="DEBUG")
 
 # MiniMax API configuration
 MINIMAX_API_URL = "https://api.minimax.io/v1"
-MINIMAX_MODEL = "MiniMax-M2.7"
+MINIMAX_MODEL = "MiniMax-M3"
 
 
 def construct_agent_list() -> List[Dict[str, Any]]:

--- a/owl/.env_template
+++ b/owl/.env_template
@@ -35,6 +35,9 @@ OPENAI_API_KEY="Your_Key"
 # NOVITA API (https://novita.ai/settings/key-management?utm_source=github_owl&utm_medium=github_readme&utm_campaign=github_link)
 # NOVITA_API_KEY="Your_Key"
 
+# MiniMax API (https://platform.minimaxi.com/)
+# MINIMAX_API_KEY="Your_Key"
+
 #===========================================
 # Tools & Services API
 #===========================================

--- a/owl/webapp.py
+++ b/owl/webapp.py
@@ -257,6 +257,7 @@ MODULE_DESCRIPTIONS = {
     "run_ppio": "Using ppio model to process tasks",
     "run_together_ai": "Using together ai model to process tasks",
     "run_novita_ai": "Using novita ai model to process tasks",
+    "run_minimax": "Using MiniMax model (MiniMax-M2.7) to process tasks",
 }
 
 
@@ -282,6 +283,9 @@ QWEN_API_KEY='Your_Key'
 
 # DeepSeek API (https://platform.deepseek.com/api_keys)
 DEEPSEEK_API_KEY='Your_Key'
+
+# MiniMax API (https://platform.minimaxi.com/)
+# MINIMAX_API_KEY='Your_Key'
 
 #===========================================
 # Tools & Services API

--- a/owl/webapp.py
+++ b/owl/webapp.py
@@ -257,7 +257,7 @@ MODULE_DESCRIPTIONS = {
     "run_ppio": "Using ppio model to process tasks",
     "run_together_ai": "Using together ai model to process tasks",
     "run_novita_ai": "Using novita ai model to process tasks",
-    "run_minimax": "Using MiniMax model (MiniMax-M2.7) to process tasks",
+    "run_minimax": "Using MiniMax model (MiniMax-M3) to process tasks",
 }
 
 

--- a/owl/webapp_jp.py
+++ b/owl/webapp_jp.py
@@ -253,6 +253,7 @@ MODULE_DESCRIPTIONS = {
     "run_azure_openai": "Azure OpenAIモデルを使用してタスクを処理します",
     "run_groq": "groqモデルを使用してタスクを処理します",
     "run_together_ai": "together aiモデルを使用してタスクを処理します",
+    "run_minimax": "MiniMaxモデル（MiniMax-M2.7）を使用してタスクを処理します",
 }
 
 
@@ -278,6 +279,9 @@ QWEN_API_KEY='あなたのキー'
 
 # DeepSeek API (https://platform.deepseek.com/api_keys)
 DEEPSEEK_API_KEY='あなたのキー'
+
+# MiniMax API (https://platform.minimaxi.com/)
+# MINIMAX_API_KEY='あなたのキー'
 
 #===========================================
 # ツール & サービス API

--- a/owl/webapp_jp.py
+++ b/owl/webapp_jp.py
@@ -253,7 +253,7 @@ MODULE_DESCRIPTIONS = {
     "run_azure_openai": "Azure OpenAIモデルを使用してタスクを処理します",
     "run_groq": "groqモデルを使用してタスクを処理します",
     "run_together_ai": "together aiモデルを使用してタスクを処理します",
-    "run_minimax": "MiniMaxモデル（MiniMax-M2.7）を使用してタスクを処理します",
+    "run_minimax": "MiniMaxモデル（MiniMax-M3）を使用してタスクを処理します",
 }
 
 

--- a/owl/webapp_zh.py
+++ b/owl/webapp_zh.py
@@ -256,6 +256,7 @@ MODULE_DESCRIPTIONS = {
     "run_ppio": "使用ppio模型处理任务",
     "run_together_ai": "使用together ai模型处理任务",
     "run_novita_ai": "使用novita ai模型处理任务",
+    "run_minimax": "使用MiniMax模型(MiniMax-M2.7)处理任务",
 }
 
 
@@ -281,6 +282,9 @@ QWEN_API_KEY='Your_Key'
 
 # DeepSeek API (https://platform.deepseek.com/api_keys)
 DEEPSEEK_API_KEY='Your_Key'
+
+# MiniMax API (https://platform.minimaxi.com/)
+# MINIMAX_API_KEY='Your_Key'
 
 #===========================================
 # Tools & Services API

--- a/owl/webapp_zh.py
+++ b/owl/webapp_zh.py
@@ -256,7 +256,7 @@ MODULE_DESCRIPTIONS = {
     "run_ppio": "使用ppio模型处理任务",
     "run_together_ai": "使用together ai模型处理任务",
     "run_novita_ai": "使用novita ai模型处理任务",
-    "run_minimax": "使用MiniMax模型(MiniMax-M2.7)处理任务",
+    "run_minimax": "使用MiniMax模型(MiniMax-M3)处理任务",
 }
 
 

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -1,0 +1,113 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+
+"""Integration tests for MiniMax model with CAMEL framework.
+
+These tests require a valid MINIMAX_API_KEY environment variable.
+They are skipped if the API key is not set.
+"""
+
+import os
+import sys
+import pathlib
+import pytest
+
+# Ensure project root is on the path
+project_root = pathlib.Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+
+MINIMAX_API_KEY = os.getenv("MINIMAX_API_KEY")
+skip_no_key = pytest.mark.skipif(
+    not MINIMAX_API_KEY,
+    reason="MINIMAX_API_KEY not set",
+)
+
+
+@skip_no_key
+class TestMiniMaxLiveAPI:
+    """Integration tests that call the actual MiniMax API."""
+
+    def test_simple_chat_completion(self):
+        """Test a simple chat completion with MiniMax API."""
+        from camel.models import ModelFactory
+        from camel.agents import ChatAgent
+        from camel.types import ModelPlatformType
+
+        model = ModelFactory.create(
+            model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
+            model_type="MiniMax-M2.7",
+            url="https://api.minimax.io/v1",
+            api_key=MINIMAX_API_KEY,
+            model_config_dict={"temperature": 0},
+        )
+
+        agent = ChatAgent(
+            "You are a helpful assistant. Answer concisely.",
+            model=model,
+        )
+
+        response = agent.step("What is 2 + 2? Reply with just the number.")
+        assert response is not None
+        assert response.msgs is not None
+        assert len(response.msgs) > 0
+        content = response.msgs[0].content
+        assert "4" in content
+
+    def test_multiple_models_creation(self):
+        """Test creating multiple MiniMax model instances for different roles."""
+        from camel.models import ModelFactory
+        from camel.types import ModelPlatformType
+
+        models = {}
+        for role in ["web", "reasoning", "coordinator"]:
+            models[role] = ModelFactory.create(
+                model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
+                model_type="MiniMax-M2.7",
+                url="https://api.minimax.io/v1",
+                api_key=MINIMAX_API_KEY,
+                model_config_dict={"temperature": 0},
+            )
+        assert len(models) == 3
+        for model in models.values():
+            assert model is not None
+
+    def test_chat_agent_with_system_prompt(self):
+        """Test creating a ChatAgent with a custom system prompt using MiniMax."""
+        from camel.models import ModelFactory
+        from camel.agents import ChatAgent
+        from camel.types import ModelPlatformType
+
+        model = ModelFactory.create(
+            model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
+            model_type="MiniMax-M2.7",
+            url="https://api.minimax.io/v1",
+            api_key=MINIMAX_API_KEY,
+            model_config_dict={"temperature": 0},
+        )
+
+        agent = ChatAgent(
+            "You are a coding assistant. Always respond with Python code.",
+            model=model,
+        )
+
+        response = agent.step("Write a one-line Python hello world program.")
+        assert response is not None
+        assert response.msgs is not None
+        content = response.msgs[0].content
+        assert "print" in content.lower()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -47,7 +47,7 @@ class TestMiniMaxLiveAPI:
 
         model = ModelFactory.create(
             model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
-            model_type="MiniMax-M2.7",
+            model_type="MiniMax-M3",
             url="https://api.minimax.io/v1",
             api_key=MINIMAX_API_KEY,
             model_config_dict={"temperature": 0},
@@ -74,7 +74,7 @@ class TestMiniMaxLiveAPI:
         for role in ["web", "reasoning", "coordinator"]:
             models[role] = ModelFactory.create(
                 model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
-                model_type="MiniMax-M2.7",
+                model_type="MiniMax-M3",
                 url="https://api.minimax.io/v1",
                 api_key=MINIMAX_API_KEY,
                 model_config_dict={"temperature": 0},
@@ -91,7 +91,7 @@ class TestMiniMaxLiveAPI:
 
         model = ModelFactory.create(
             model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
-            model_type="MiniMax-M2.7",
+            model_type="MiniMax-M3",
             url="https://api.minimax.io/v1",
             api_key=MINIMAX_API_KEY,
             model_config_dict={"temperature": 0},

--- a/tests/test_minimax_unit.py
+++ b/tests/test_minimax_unit.py
@@ -1,0 +1,227 @@
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ========= Copyright 2023-2024 @ CAMEL-AI.org. All Rights Reserved. =========
+
+"""Unit tests for MiniMax model integration with OWL."""
+
+import os
+import sys
+import pathlib
+import importlib
+from unittest.mock import patch, MagicMock
+import pytest
+
+
+# Ensure project root is on the path
+project_root = pathlib.Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+
+class TestMiniMaxModuleConstants:
+    """Test MiniMax module constants and configuration."""
+
+    def test_minimax_api_url(self):
+        """Test that MiniMax API URL is correctly defined."""
+        module_path = project_root / "examples" / "run_minimax.py"
+        content = module_path.read_text()
+        assert 'MINIMAX_API_URL = "https://api.minimax.io/v1"' in content
+
+    def test_minimax_model_name(self):
+        """Test that MiniMax model name is correctly defined."""
+        module_path = project_root / "examples" / "run_minimax.py"
+        content = module_path.read_text()
+        assert 'MINIMAX_MODEL = "MiniMax-M2.7"' in content
+
+    def test_minimax_model_is_valid(self):
+        """Test that the configured model name is a known MiniMax model."""
+        module_path = project_root / "examples" / "run_minimax.py"
+        content = module_path.read_text()
+        # Extract model name from source
+        import re
+        match = re.search(r'MINIMAX_MODEL\s*=\s*"([^"]+)"', content)
+        assert match is not None
+        model_name = match.group(1)
+        valid_models = [
+            "MiniMax-M2.7",
+            "MiniMax-M2.5",
+            "MiniMax-M2.5-highspeed",
+        ]
+        assert model_name in valid_models
+
+
+class TestMiniMaxWebappIntegration:
+    """Test MiniMax integration with the webapp module selection."""
+
+    def test_minimax_in_webapp_en_modules(self):
+        """Test that run_minimax is listed in English webapp MODULE_DESCRIPTIONS."""
+        sys.path.insert(0, str(project_root / "owl"))
+        # Read the file directly to check for the module entry
+        webapp_path = project_root / "owl" / "webapp.py"
+        content = webapp_path.read_text()
+        assert '"run_minimax"' in content
+        assert "MiniMax" in content
+
+    def test_minimax_in_webapp_zh_modules(self):
+        """Test that run_minimax is listed in Chinese webapp MODULE_DESCRIPTIONS."""
+        webapp_path = project_root / "owl" / "webapp_zh.py"
+        content = webapp_path.read_text()
+        assert '"run_minimax"' in content
+        assert "MiniMax" in content
+
+    def test_minimax_in_webapp_jp_modules(self):
+        """Test that run_minimax is listed in Japanese webapp MODULE_DESCRIPTIONS."""
+        webapp_path = project_root / "owl" / "webapp_jp.py"
+        content = webapp_path.read_text()
+        assert '"run_minimax"' in content
+        assert "MiniMax" in content
+
+
+class TestMiniMaxEnvTemplate:
+    """Test MiniMax configuration in environment templates."""
+
+    def test_minimax_api_key_in_env_template(self):
+        """Test that MINIMAX_API_KEY is documented in .env_template."""
+        env_template_path = project_root / "owl" / ".env_template"
+        content = env_template_path.read_text()
+        assert "MINIMAX_API_KEY" in content
+
+    def test_minimax_platform_url_in_env_template(self):
+        """Test that MiniMax platform URL is documented in .env_template."""
+        env_template_path = project_root / "owl" / ".env_template"
+        content = env_template_path.read_text()
+        assert "platform.minimaxi.com" in content
+
+    def test_minimax_in_webapp_env_template(self):
+        """Test that MINIMAX_API_KEY is in webapp DEFAULT_ENV_TEMPLATE."""
+        webapp_path = project_root / "owl" / "webapp.py"
+        content = webapp_path.read_text()
+        assert "MINIMAX_API_KEY" in content
+
+
+class TestMiniMaxReadme:
+    """Test MiniMax documentation in README files."""
+
+    def test_minimax_in_readme_en(self):
+        """Test that MiniMax is mentioned in English README."""
+        readme_path = project_root / "README.md"
+        content = readme_path.read_text()
+        assert "run_minimax" in content
+        assert "MiniMax" in content
+
+    def test_minimax_in_readme_zh(self):
+        """Test that MiniMax is mentioned in Chinese README."""
+        readme_path = project_root / "README_zh.md"
+        content = readme_path.read_text()
+        assert "run_minimax" in content
+        assert "MiniMax" in content
+
+
+class TestMiniMaxModuleStructure:
+    """Test the structure of the MiniMax example module."""
+
+    def test_module_defines_construct_agent_list(self):
+        """Test that run_minimax defines construct_agent_list function."""
+        module_path = project_root / "examples" / "run_minimax.py"
+        content = module_path.read_text()
+        assert "def construct_agent_list()" in content
+
+    def test_module_defines_construct_workforce(self):
+        """Test that run_minimax defines construct_workforce function."""
+        module_path = project_root / "examples" / "run_minimax.py"
+        content = module_path.read_text()
+        assert "def construct_workforce()" in content
+
+    def test_module_defines_main(self):
+        """Test that run_minimax defines main function."""
+        module_path = project_root / "examples" / "run_minimax.py"
+        content = module_path.read_text()
+        assert "def main():" in content
+
+    def test_module_uses_openai_compatible_platform(self):
+        """Test that the module uses OPENAI_COMPATIBLE_MODEL platform type."""
+        module_path = project_root / "examples" / "run_minimax.py"
+        content = module_path.read_text()
+        assert "ModelPlatformType.OPENAI_COMPATIBLE_MODEL" in content
+
+    def test_module_reads_minimax_api_key(self):
+        """Test that the module reads MINIMAX_API_KEY from environment."""
+        module_path = project_root / "examples" / "run_minimax.py"
+        content = module_path.read_text()
+        assert 'os.getenv("MINIMAX_API_KEY")' in content
+
+    def test_module_uses_temperature_zero(self):
+        """Test that all models use temperature=0 for deterministic output."""
+        module_path = project_root / "examples" / "run_minimax.py"
+        content = module_path.read_text()
+        assert '"temperature": 0' in content
+
+    def test_module_creates_three_agents(self):
+        """Test that the module creates the expected agent types."""
+        module_path = project_root / "examples" / "run_minimax.py"
+        content = module_path.read_text()
+        assert "Web Agent" in content
+        assert "Document Processing Agent" in content
+        assert "Reasoning Coding Agent" in content
+
+
+class TestMiniMaxModelFactory:
+    """Test MiniMax model creation via CAMEL ModelFactory."""
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_model_factory_create_with_minimax(self):
+        """Test that ModelFactory.create works with MiniMax configuration."""
+        from camel.models import ModelFactory
+        from camel.types import ModelPlatformType
+
+        model = ModelFactory.create(
+            model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
+            model_type="MiniMax-M2.7",
+            url="https://api.minimax.io/v1",
+            api_key="test-key-123",
+            model_config_dict={"temperature": 0},
+        )
+        assert model is not None
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_model_factory_create_m25(self):
+        """Test that ModelFactory.create works with MiniMax-M2.5."""
+        from camel.models import ModelFactory
+        from camel.types import ModelPlatformType
+
+        model = ModelFactory.create(
+            model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
+            model_type="MiniMax-M2.5",
+            url="https://api.minimax.io/v1",
+            api_key="test-key-123",
+            model_config_dict={"temperature": 0},
+        )
+        assert model is not None
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_model_factory_create_m25_highspeed(self):
+        """Test that ModelFactory.create works with MiniMax-M2.5-highspeed."""
+        from camel.models import ModelFactory
+        from camel.types import ModelPlatformType
+
+        model = ModelFactory.create(
+            model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
+            model_type="MiniMax-M2.5-highspeed",
+            url="https://api.minimax.io/v1",
+            api_key="test-key-123",
+            model_config_dict={"temperature": 0},
+        )
+        assert model is not None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_minimax_unit.py
+++ b/tests/test_minimax_unit.py
@@ -40,7 +40,7 @@ class TestMiniMaxModuleConstants:
         """Test that MiniMax model name is correctly defined."""
         module_path = project_root / "examples" / "run_minimax.py"
         content = module_path.read_text()
-        assert 'MINIMAX_MODEL = "MiniMax-M2.7"' in content
+        assert 'MINIMAX_MODEL = "MiniMax-M3"' in content
 
     def test_minimax_model_is_valid(self):
         """Test that the configured model name is a known MiniMax model."""
@@ -52,9 +52,9 @@ class TestMiniMaxModuleConstants:
         assert match is not None
         model_name = match.group(1)
         valid_models = [
+            "MiniMax-M3",
             "MiniMax-M2.7",
-            "MiniMax-M2.5",
-            "MiniMax-M2.5-highspeed",
+            "MiniMax-M2.7-highspeed",
         ]
         assert model_name in valid_models
 
@@ -185,6 +185,21 @@ class TestMiniMaxModelFactory:
 
         model = ModelFactory.create(
             model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
+            model_type="MiniMax-M3",
+            url="https://api.minimax.io/v1",
+            api_key="test-key-123",
+            model_config_dict={"temperature": 0},
+        )
+        assert model is not None
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
+    def test_model_factory_create_m27(self):
+        """Test that ModelFactory.create works with MiniMax-M2.7."""
+        from camel.models import ModelFactory
+        from camel.types import ModelPlatformType
+
+        model = ModelFactory.create(
+            model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
             model_type="MiniMax-M2.7",
             url="https://api.minimax.io/v1",
             api_key="test-key-123",
@@ -193,29 +208,14 @@ class TestMiniMaxModelFactory:
         assert model is not None
 
     @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
-    def test_model_factory_create_m25(self):
-        """Test that ModelFactory.create works with MiniMax-M2.5."""
+    def test_model_factory_create_m27_highspeed(self):
+        """Test that ModelFactory.create works with MiniMax-M2.7-highspeed."""
         from camel.models import ModelFactory
         from camel.types import ModelPlatformType
 
         model = ModelFactory.create(
             model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
-            model_type="MiniMax-M2.5",
-            url="https://api.minimax.io/v1",
-            api_key="test-key-123",
-            model_config_dict={"temperature": 0},
-        )
-        assert model is not None
-
-    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"})
-    def test_model_factory_create_m25_highspeed(self):
-        """Test that ModelFactory.create works with MiniMax-M2.5-highspeed."""
-        from camel.models import ModelFactory
-        from camel.types import ModelPlatformType
-
-        model = ModelFactory.create(
-            model_platform=ModelPlatformType.OPENAI_COMPATIBLE_MODEL,
-            model_type="MiniMax-M2.5-highspeed",
+            model_type="MiniMax-M2.7-highspeed",
             url="https://api.minimax.io/v1",
             api_key="test-key-123",
             model_config_dict={"temperature": 0},


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimaxi.com/) as an alternative LLM provider for the OWL multi-agent workforce, using CAMEL's OPENAI_COMPATIBLE_MODEL platform type. The integration defaults to **MiniMax-M3**, the latest model in the MiniMax family.

### Changes

- **examples/run_minimax.py**: Full workforce example using MiniMax-M3 as the default model with web, document processing, and reasoning agents
- **owl/.env_template**: Add MINIMAX_API_KEY configuration entry
- **owl/webapp.py**, **owl/webapp_zh.py**, **owl/webapp_jp.py**: Add run_minimax to MODULE_DESCRIPTIONS (referencing M3) and MINIMAX_API_KEY to DEFAULT_ENV_TEMPLATE
- **README.md**, **README_zh.md**: Add MiniMax to supported models section (referencing M3)
- **tests/test_minimax_unit.py**: 21 unit tests covering module structure, config, webapp integration, README docs, and ModelFactory creation for M3 / M2.7 / M2.7-highspeed
- **tests/test_minimax_integration.py**: 3 integration tests verifying live API chat completion with M3

### About MiniMax

- **API**: OpenAI-compatible (https://api.minimax.io/v1)
- **Default model**: MiniMax-M3 (512K context, up to 128K output, supports image input)
- **Alternatives kept**: MiniMax-M2.7, MiniMax-M2.7-highspeed
- **Features**: Tool calling, temperature=0 support

## Test plan

- [x] Structural tests pass (model name, API URL, webapp/README references all use M3)
- [x] Unit tests updated to validate M3 + M2.7 family (M2.5 removed)
- [x] Integration tests updated to call M3 via live API
- [ ] Verify python examples/run_minimax.py runs a complete workforce task
- [ ] Verify webapp shows run_minimax in module dropdown